### PR TITLE
feat: add support for sales_order streams

### DIFF
--- a/tap_younium/client.py
+++ b/tap_younium/client.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from typing import Any, Callable, Iterable
-from urllib.parse import parse_qs, parse_qsl, urlparse
+from typing import Any, Callable
+from urllib.parse import parse_qsl, urlparse
 
 import requests
-from singer_sdk.helpers.jsonpath import extract_jsonpath
-from singer_sdk.pagination import BaseAPIPaginator, JSONPathPaginator
 from singer_sdk.streams import RESTStream
 
 from tap_younium.auth import YouniumAuthenticator

--- a/tap_younium/schemas/subscription.json
+++ b/tap_younium/schemas/subscription.json
@@ -24,10 +24,10 @@
       "type": ["string", "null"]
     },
     "effectiveStartDate": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "effectiveEndDate": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "cancellationDate": {
       "type": ["string", "null"]
@@ -39,28 +39,28 @@
       "type": "string"
     },
     "noticePeriodDate": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "lastRenewalDate": {
       "type": ["string", "null"]
     },
     "noticePeriod": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "term": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "renewalTerm": {
-      "type": "number"
+      "type": ["number", "null"]
     },
     "isAutoRenewed": {
-      "type": "boolean"
+      "type": ["boolean", "null"]
     },
     "orderType": {
       "type": "string"
     },
     "termType": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "orderPaymentMethod": {
       "type": "string"
@@ -78,7 +78,7 @@
       "type": ["string", "null"]
     },
     "invoiceAddress": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "id": {
           "type": "string"
@@ -260,10 +260,10 @@
                   "type": "string"
                 },
                 "effectiveStartDate": {
-                  "type": "string"
+                  "type": ["string", "null"]
                 },
                 "effectiveEndDate": {
-                  "type": "string"
+                  "type": ["string", "null"]
                 },
                 "quantity": {
                   "type": "number"
@@ -423,7 +423,7 @@
                   "type": ["string", "null"]
                 },
                 "cmrr": {
-                  "type": "object",
+                  "type": ["object", "null"],
                   "properties": {
                     "amount": {
                       "type": "number"
@@ -443,7 +443,7 @@
                   }
                 },
                 "acv": {
-                  "type": "object",
+                  "type": ["object", "null"],
                   "properties": {
                     "amount": {
                       "type": "number"
@@ -463,7 +463,7 @@
                   }
                 },
                 "tcv": {
-                  "type": "object",
+                  "type": ["object", "null"],
                   "properties": {
                     "amount": {
                       "type": "number"
@@ -503,7 +503,7 @@
                   }
                 },
                 "oneTimeFees": {
-                  "type": "object",
+                  "type": ["object", "null"],
                   "properties": {
                     "amount": {
                       "type": "number"
@@ -542,7 +542,7 @@
             "type": ["string", "null"]
           },
           "cmrr": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
               "amount": {
                 "type": "number"
@@ -562,7 +562,7 @@
             }
           },
           "acv": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
               "amount": {
                 "type": "number"
@@ -582,7 +582,7 @@
             }
           },
           "emrr": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
               "amount": {
                 "type": "number"
@@ -602,7 +602,7 @@
             }
           },
           "oneTimeFees": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
               "amount": {
                 "type": "number"
@@ -622,7 +622,7 @@
             }
           },
           "tcv": {
-            "type": "object",
+            "type": ["object", "null"],
             "properties": {
               "amount": {
                 "type": "number"
@@ -736,7 +736,7 @@
       "properties": {}
     },
     "cmrr": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "amount": {
           "type": "number"
@@ -756,7 +756,7 @@
       }
     },
     "acv": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "amount": {
           "type": "number"
@@ -776,7 +776,7 @@
       }
     },
     "emrr": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "amount": {
           "type": "number"
@@ -796,7 +796,7 @@
       }
     },
     "oneTimeFees": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "amount": {
           "type": "number"
@@ -816,7 +816,7 @@
       }
     },
     "tcv": {
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "amount": {
           "type": "number"

--- a/tap_younium/streams.py
+++ b/tap_younium/streams.py
@@ -9,10 +9,8 @@ from tap_younium.client import YouniumStream
 
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
-
-class SubscriptionsStream(YouniumStream):
-    name = "subscriptions"
-    path = "/Subscriptions"
+# base class for order based streams
+class OrderStream(YouniumStream):
     primary_keys = ["id"]
     replication_key = None
 
@@ -34,7 +32,10 @@ class SubscriptionsStream(YouniumStream):
         self.apply_custom_fields(schema["properties"]["products"]["items"]["properties"]["charges"]["items"], custom.get("charge"))
 
         return schema
-    
+
+class SubscriptionsStream(OrderStream):
+    name = "subscriptions"
+    path = "/Subscriptions"
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
@@ -42,9 +43,9 @@ class SubscriptionsStream(YouniumStream):
             "orderNumber": record["orderNumber"],
         }
 
-
-class SubscriptionVersionsStream(YouniumStream):
+class SubscriptionVersionsStream(OrderStream):
     name = "subscription_versions"
+    path = "/Subscriptions/{orderNumber}/versions"
     
     parent_stream_type = SubscriptionsStream
     ignore_parent_replication_keys = True
@@ -52,29 +53,26 @@ class SubscriptionVersionsStream(YouniumStream):
 
     records_jsonpath = "$[*]"  # the versions resource returns plain arrays
 
-    # Path is auto-populated using parent context keys:
-    path = "/Subscriptions/{orderNumber}/versions"
-    primary_keys = ["id"]
+class SalesOrdersStream(OrderStream):
+    name = "sales_orders"
+    path = "/SalesOrders"
 
-    # todo: share with SubscriptionsStream
-    @property
-    def schema(self) -> dict:
-        """Get dynamic schema including the configured tag schema
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a context dictionary for child streams."""
+        return {
+            "orderNumber": record["orderNumber"],
+        }
 
-        Returns:
-            JSON Schema dictionary for this stream.
-        """
+class SalesOrderVersionsStream(OrderStream):
+    name = "sales_order_versions"
+    path = "/SalesOrders/{orderNumber}/versions"
     
-        schema_filepath = SCHEMAS_DIR / "subscription.json"
-        schema = json.loads(Path(schema_filepath).read_text())
+    parent_stream_type = SalesOrdersStream
+    ignore_parent_replication_keys = True
+    state_partitioning_keys = []
 
-        custom = self.config["custom_field_schemas"]
-        
-        self.apply_custom_fields(schema, custom.get("subscription"))
-        self.apply_custom_fields(schema["properties"]["products"]["items"], custom.get("product"))
-        self.apply_custom_fields(schema["properties"]["products"]["items"]["properties"]["charges"]["items"], custom.get("charge"))
+    records_jsonpath = "$[*]"  # the versions resource returns plain arrays
 
-        return schema
     
 class InvoicesStream(YouniumStream):
     name = "invoices"

--- a/tap_younium/tap.py
+++ b/tap_younium/tap.py
@@ -63,6 +63,8 @@ class TapYounium(Tap):
         return [
             streams.SubscriptionsStream(self),
             streams.SubscriptionVersionsStream(self),
+            streams.SalesOrdersStream(self),
+            streams.SalesOrderVersionsStream(self),
             streams.InvoicesStream(self),
             streams.ProductsStream(self),
             streams.BookingsStream(self),


### PR DESCRIPTION
sales orders are like subscriptions, but a different API endpoint
